### PR TITLE
[WIP] add USERNAME_FIELD_NAME environment variable

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -61,3 +61,6 @@ typings/
 
 # next.js build output
 .next
+
+# Webstorm IDE directory
+.idea

--- a/src/config.js
+++ b/src/config.js
@@ -1,4 +1,5 @@
 exports.USER_FIELDS = process.env.USER_FIELDS ? process.env.USER_FIELDS.split(',') : [];
+exports.USERNAME_FIELD_NAME = process.env.USERNAME_FIELD_NAME || "email"; // username | email
 exports.USER_REGISTRATION_AUTO_ACTIVE = process.env.USER_REGISTRATION_AUTO_ACTIVE || false;
 exports.HASURA_GQE_ENDPOINT = process.env.HASURA_GQE_ENDPOINT || 'https://hasura.your-app.com/v1alpha1/graphql';
 exports.HASURA_GQE_ADMIN_SECRET = process.env.HASURA_GQE_ADMIN_SECRET || 'hasura-admin-secret';


### PR DESCRIPTION
@elitan Based on this PR we can use more flexible table schema in the other word we also can use `username` for username field.

**Problem:**
Now we forced to use `email` and `password` field in user tables.  In a system I'm working on it email is not equal username but HB+ forced me to enter email for register and login because of this check: `email: Joi.string().email().required()`.

**Solution:**
Now we have a new environment variable called `USERNAME_FIELD_NAME` and we can set this as `email` or `username` and HB+ work with both of them.

**Task List:**
- [x] /register
- [ ] / sign-in
- [ ] /activate-account
- [ ] /new-password
- [ ] add docs to readme